### PR TITLE
Невиконання deploy за умовою не спричиняє вихід з помилкою

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    continue-on-error: true
     
     steps:
       - name: Setup Pages


### PR DESCRIPTION
Дивись докладніше тут: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error